### PR TITLE
Rename `dims` to `array_dims` after vcztools change

### DIFF
--- a/tests/test_normalise.py
+++ b/tests/test_normalise.py
@@ -13,15 +13,29 @@ from .utils import compare_vcf_and_vcz, convert_vcf_to_vcz
 def create_variant_only_vcz(variant_contig, variant_position, variant_allele):
     store = zarr.storage.MemoryStore()
     root = zarr.create_group(store=store)
-    root.create_array(name="contig_id", data=np.unique(variant_contig).astype(str))
     root.create_array(
-        name="variant_contig", data=np.array(variant_contig, dtype=np.int32)
+        name="contig_id",
+        data=np.unique(variant_contig).astype(str),
+        dimension_names=["contigs"],
     )
     root.create_array(
-        name="variant_position", data=np.array(variant_position, dtype=np.int32)
+        name="variant_contig",
+        data=np.array(variant_contig, dtype=np.int32),
+        dimension_names=["variants"],
     )
-    root.create_array(name="variant_allele", data=np.array(variant_allele, dtype="T"))
-    root.create_array(name="sample_id", data=np.array([], dtype="T"))
+    root.create_array(
+        name="variant_position",
+        data=np.array(variant_position, dtype=np.int32),
+        dimension_names=["variants"],
+    )
+    root.create_array(
+        name="variant_allele",
+        data=np.array(variant_allele, dtype="T"),
+        dimension_names=["variants", "alleles"],
+    )
+    root.create_array(
+        name="sample_id", data=np.array([], dtype="T"), dimension_names=["samples"]
+    )
     return store
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ import numpy as np
 import vcztools.cli as cli
 import zarr
 from bio2zarr import vcf
-from vcztools.vcf_writer import dims
+from vcztools.utils import array_dims
 
 from vczstore.utils import missing_val
 
@@ -318,8 +318,8 @@ def check_removed_sample(vcz, sample_id):
         arr = root[var]
         if (
             var.startswith("call_")
-            and dims(arr)[0] == "variants"
-            and dims(arr)[1] == "samples"
+            and array_dims(arr)[0] == "variants"
+            and array_dims(arr)[1] == "samples"
         ):
             np.testing.assert_array_equal(
                 root[var][:][:, selection, ...], missing_val(arr)

--- a/uv.lock
+++ b/uv.lock
@@ -1630,8 +1630,8 @@ test = [
 
 [[package]]
 name = "vcztools"
-version = "0.1.3.dev12"
-source = { git = "https://github.com/sgkit-dev/vcztools.git#a12a9f60d76f84e1d09538d41867a06424c9400f" }
+version = "0.1.3.dev41"
+source = { git = "https://github.com/sgkit-dev/vcztools.git#5c24ff2fde85ed974ccf85981675a3a546a5ba35" }
 dependencies = [
     { name = "click" },
     { name = "numpy" },

--- a/vczstore/zarr_impl.py
+++ b/vczstore/zarr_impl.py
@@ -6,8 +6,7 @@ from bio2zarr.zarr_utils import create_group_array, get_compressor_config
 from more_itertools import peekable
 from vcztools.constants import STR_FILL, STR_MISSING
 from vcztools.retrieval import variant_iter
-from vcztools.utils import search
-from vcztools.vcf_writer import dims
+from vcztools.utils import array_dims, search
 
 from vczstore.utils import missing_val, variant_chunk_slices
 
@@ -56,7 +55,7 @@ def append(vcz1, vcz2):
                 new_shape = (arr.shape[0], new_num_samples, arr.shape[2])
                 arr.resize(new_shape)
             else:
-                raise ValueError("unsupported number of dims")
+                raise ValueError("unsupported number of array_dims")
 
     # append genotype fields
     for variant_selection in variant_chunk_slices(root1):
@@ -85,8 +84,8 @@ def remove(vcz, sample_id):
             arr = root[var]
             if (
                 var.startswith("call_")
-                and dims(arr)[0] == "variants"
-                and dims(arr)[1] == "samples"
+                and array_dims(arr)[0] == "variants"
+                and array_dims(arr)[1] == "samples"
             ):
                 arr[variant_selection, sample_selection, ...] = missing_val(arr)
 
@@ -118,7 +117,7 @@ def normalise(vcz1, vcz2, vcz2_norm):
                 dtype=data.dtype,
                 compressor=get_compressor_config(arr),
                 chunks=chunks,
-                dimension_names=dims(arr),
+                dimension_names=array_dims(arr),
             )
         else:
             # copy across from vcz1 or vcz2
@@ -134,7 +133,7 @@ def normalise(vcz1, vcz2, vcz2_norm):
                 dtype=arr.dtype,
                 compressor=get_compressor_config(arr),
                 chunks=arr.chunks,
-                dimension_names=dims(arr),
+                dimension_names=array_dims(arr),
             )
 
 


### PR DESCRIPTION
Fixes following https://github.com/sgkit-dev/vcztools/pull/281