### PR TITLE
Append with direct copy when possible

### DIFF
--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -352,7 +352,7 @@ def test_append_fails_for_misaligned_source_variant_chunks():
     assert root1_after["call_genotype"].shape == (2, 1, 2)
 
 
-def test_append_fails_before_mutating_when_direct_copy_chunks_differ():
+def test_append_rewrites_when_direct_copy_chunks_differ():
     store1 = _create_minimal_append_store(
         ["S1", "S2"],
         _make_genotype(2, 2),
@@ -364,12 +364,15 @@ def test_append_fails_before_mutating_when_direct_copy_chunks_differ():
         samples_chunk_size=1,
     )
 
-    with pytest.raises(ValueError, match="matching chunks"):
-        append(store1, store2)
+    append(store1, store2)
 
     root1_after = zarr.open_group(store=store1, mode="r")
-    np.testing.assert_array_equal(root1_after["sample_id"][:], np.array(["S1", "S2"]))
-    assert root1_after["call_genotype"].shape == (2, 2, 2)
+    np.testing.assert_array_equal(
+        root1_after["sample_id"][:], np.array(["S1", "S2", "S3", "S4"])
+    )
+    np.testing.assert_array_equal(
+        root1_after["call_genotype"][:, 2:, :], _make_genotype(2, 2)
+    )
 
 
 def test_append_fails_before_mutating_when_secondary_call_array_is_misaligned():
@@ -393,13 +396,14 @@ def test_append_fails_before_mutating_when_secondary_call_array_is_misaligned():
             dimension_names=["variants", "samples"],
         )
 
-    with pytest.raises(ValueError, match="sample chunk-aligned slices"):
-        append(store1, store2)
+    append(store1, store2)
 
     root1_after = zarr.open_group(store=store1, mode="r")
-    np.testing.assert_array_equal(root1_after["sample_id"][:], np.array(["S1", "S2"]))
-    assert root1_after["call_a"].shape == (2, 2, 2)
-    assert root1_after["call_z"].shape == (2, 2)
+    np.testing.assert_array_equal(
+        root1_after["sample_id"][:], np.array(["S1", "S2", "S3", "S4", "S5", "S6"])
+    )
+    np.testing.assert_array_equal(root1_after["call_a"][:, 2:, :], _make_genotype(2, 4))
+    np.testing.assert_array_equal(root1_after["call_z"][:, 2:], np.ones((2, 4)))
 
 
 def test_append_preserves_sparse_source_chunks_as_fill_chunks():
@@ -424,6 +428,52 @@ def test_append_preserves_sparse_source_chunks_as_fill_chunks():
 
     append(store1, store2, io_concurrency=2)
 
+    root = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(root["call_genotype"][:, 2:4, :], incoming[:, :2, :])
+    np.testing.assert_array_equal(
+        root["call_genotype"][:, 4:6, :],
+        np.zeros((2, 2, 2), dtype=np.int8),
+    )
+
+
+def test_append_deletes_stale_destination_chunk_when_source_chunk_is_sparse():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2"],
+        _make_genotype(2, 2),
+        samples_chunk_size=2,
+    )
+    incoming = _make_genotype(2, 4)
+    store2 = _create_minimal_append_store(
+        ["S3", "S4", "S5", "S6"],
+        incoming,
+        samples_chunk_size=2,
+    )
+
+    dest_genotype = zarr.open_group(store=store1, mode="r+")["call_genotype"]
+    source_genotype = zarr.open_group(store=store2, mode="r+")["call_genotype"]
+    source_chunk = (
+        source_genotype.store_path
+        / source_genotype.metadata.encode_chunk_key((0, 1, 0))
+    )
+    stale_dest_chunk = (
+        dest_genotype.store_path / dest_genotype.metadata.encode_chunk_key((0, 2, 0))
+    )
+    sync(
+        stale_dest_chunk.set(
+            sync(
+                (
+                    dest_genotype.store_path
+                    / dest_genotype.metadata.encode_chunk_key((0, 0, 0))
+                ).get()
+            )
+        )
+    )
+    sync(source_chunk.delete())
+    assert sync(stale_dest_chunk.get()) is not None
+
+    append(store1, store2, io_concurrency=2)
+
+    assert sync(stale_dest_chunk.get()) is None
     root = zarr.open_group(store=store1, mode="r")
     np.testing.assert_array_equal(root["call_genotype"][:, 2:4, :], incoming[:, :2, :])
     np.testing.assert_array_equal(
@@ -540,7 +590,7 @@ def _create_minimal_append_store(
     return store
 
 
-def test_append_preserves_order_when_destination_is_chunk_aligned():
+def test_append_preserves_order():
     store1 = _create_minimal_append_store(
         ["S1", "S2"],
         _make_genotype(2, 2),
@@ -561,7 +611,7 @@ def test_append_preserves_order_when_destination_is_chunk_aligned():
     np.testing.assert_array_equal(root["call_genotype"][:, 2:, :], _make_genotype(2, 4))
 
 
-def test_append_fills_partial_destination_chunk_from_incoming_tail():
+def test_append_preserves_order_when_destination_is_not_chunk_aligned():
     store1 = _create_minimal_append_store(
         ["S1", "S2", "S3"],
         _make_genotype(2, 3),
@@ -579,7 +629,46 @@ def test_append_fills_partial_destination_chunk_from_incoming_tail():
     root = zarr.open_group(store=store1, mode="r")
     np.testing.assert_array_equal(
         root["sample_id"][:],
-        np.array(["S1", "S2", "S3", "I5", "I1", "I2", "I3", "I4"]),
+        np.array(["S1", "S2", "S3", "I1", "I2", "I3", "I4", "I5"]),
     )
-    expected = np.concatenate([incoming[:, 4:5, :], incoming[:, :4, :]], axis=1)
-    np.testing.assert_array_equal(root["call_genotype"][:, 3:, :], expected)
+    np.testing.assert_array_equal(root["call_genotype"][:, 3:, :], incoming)
+
+
+def test_require_direct_copy_fails_before_mutating_when_destination_is_not_aligned():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2", "S3"],
+        _make_genotype(2, 3),
+        samples_chunk_size=2,
+    )
+    store2 = _create_minimal_append_store(
+        ["I1", "I2", "I3", "I4"],
+        _make_genotype(2, 4),
+        samples_chunk_size=2,
+    )
+
+    with pytest.raises(ValueError, match="direct-only append"):
+        append(store1, store2, require_direct_copy=True)
+
+    root = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(root["sample_id"][:], np.array(["S1", "S2", "S3"]))
+    assert root["call_genotype"].shape == (2, 3, 2)
+
+
+def test_require_direct_copy_fails_before_mutating_when_incoming_is_not_aligned():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2"],
+        _make_genotype(2, 2),
+        samples_chunk_size=2,
+    )
+    store2 = _create_minimal_append_store(
+        ["I1", "I2", "I3"],
+        _make_genotype(2, 3),
+        samples_chunk_size=2,
+    )
+
+    with pytest.raises(ValueError, match="direct-only append"):
+        append(store1, store2, require_direct_copy=True)
+
+    root = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(root["sample_id"][:], np.array(["S1", "S2"]))
+    assert root["call_genotype"].shape == (2, 2, 2)

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -26,6 +26,7 @@
 import numpy as np
 import pytest
 import zarr
+from zarr.core.sync import sync
 
 from vczstore.append import append
 
@@ -61,7 +62,9 @@ def test_append(tmp_path, samples_chunk_size):
 
 
 def test_append_from_variants_list(tmp_path):
-    vcz0 = convert_vcf_to_vcz("sample-variants.vcf.gz", tmp_path, ploidy=2)
+    vcz0 = convert_vcf_to_vcz(
+        "sample-variants.vcf.gz", tmp_path, ploidy=2, samples_chunk_size=2
+    )
     vcz1 = convert_vcf_to_vcz("sample-part1.vcf.gz", tmp_path)
 
     # check samples query
@@ -349,6 +352,86 @@ def test_append_fails_for_misaligned_source_variant_chunks():
     assert root1_after["call_genotype"].shape == (2, 1, 2)
 
 
+def test_append_fails_before_mutating_when_direct_copy_chunks_differ():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2"],
+        _make_genotype(2, 2),
+        samples_chunk_size=2,
+    )
+    store2 = _create_minimal_append_store(
+        ["S3", "S4"],
+        _make_genotype(2, 2),
+        samples_chunk_size=1,
+    )
+
+    with pytest.raises(ValueError, match="matching chunks"):
+        append(store1, store2)
+
+    root1_after = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(root1_after["sample_id"][:], np.array(["S1", "S2"]))
+    assert root1_after["call_genotype"].shape == (2, 2, 2)
+
+
+def test_append_fails_before_mutating_when_secondary_call_array_is_misaligned():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2"],
+        _make_genotype(2, 2),
+        samples_chunk_size=2,
+        call_name="call_a",
+    )
+    store2 = _create_minimal_append_store(
+        ["S3", "S4", "S5", "S6"],
+        _make_genotype(2, 4),
+        samples_chunk_size=2,
+        call_name="call_a",
+    )
+    for store, width in [(store1, 2), (store2, 4)]:
+        zarr.open_group(store=store, mode="r+").create_array(
+            "call_z",
+            data=np.ones((2, width), dtype=np.int8),
+            chunks=(2, 4),
+            dimension_names=["variants", "samples"],
+        )
+
+    with pytest.raises(ValueError, match="sample chunk-aligned slices"):
+        append(store1, store2)
+
+    root1_after = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(root1_after["sample_id"][:], np.array(["S1", "S2"]))
+    assert root1_after["call_a"].shape == (2, 2, 2)
+    assert root1_after["call_z"].shape == (2, 2)
+
+
+def test_append_preserves_sparse_source_chunks_as_fill_chunks():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2"],
+        _make_genotype(2, 2),
+        samples_chunk_size=2,
+    )
+    incoming = _make_genotype(2, 4)
+    store2 = _create_minimal_append_store(
+        ["S3", "S4", "S5", "S6"],
+        incoming,
+        samples_chunk_size=2,
+    )
+    source_genotype = zarr.open_group(store=store2, mode="r+")["call_genotype"]
+    sync(
+        (
+            source_genotype.store_path
+            / source_genotype.metadata.encode_chunk_key((0, 1, 0))
+        ).delete()
+    )
+
+    append(store1, store2, io_concurrency=2)
+
+    root = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(root["call_genotype"][:, 2:4, :], incoming[:, :2, :])
+    np.testing.assert_array_equal(
+        root["call_genotype"][:, 4:6, :],
+        np.zeros((2, 2, 2), dtype=np.int8),
+    )
+
+
 def test_append_multiple_chunks(tmp_path):
     vcz1 = convert_vcf_to_vcz(
         "chr22-part1.vcf.gz", tmp_path, variants_chunk_size=10, samples_chunk_size=50
@@ -403,3 +486,100 @@ def test_append_icechunk(tmp_path):
         "view --no-version --zarr-backend-storage icechunk",
         vcz1,
     )
+
+
+def _make_genotype(num_variants, num_samples):
+    values = np.zeros((num_variants, num_samples, 2), dtype=np.int8)
+    for variant_index in range(num_variants):
+        for sample_index in range(num_samples):
+            values[variant_index, sample_index, 0] = variant_index
+            values[variant_index, sample_index, 1] = sample_index
+    return values
+
+
+def _create_minimal_append_store(
+    sample_ids, genotype, *, samples_chunk_size, call_name="call_genotype"
+):
+    store = zarr.storage.MemoryStore()
+    root = zarr.create_group(store=store)
+    root.create_array(
+        "contig_id",
+        data=np.array(["0"]),
+        dimension_names=["contigs"],
+    )
+    root.create_array(
+        "variant_contig",
+        data=np.array([0, 0], dtype=np.int32),
+        chunks=(2,),
+        dimension_names=["variants"],
+    )
+    root.create_array(
+        "variant_position",
+        data=np.array([1, 2], dtype=np.int32),
+        chunks=(2,),
+        dimension_names=["variants"],
+    )
+    root.create_array(
+        "variant_allele",
+        data=np.array([["A", "T"], ["C", "G"]]),
+        chunks=(2, 2),
+        dimension_names=["variants", "alleles"],
+    )
+    root.create_array(
+        "sample_id",
+        data=np.array(sample_ids),
+        chunks=(samples_chunk_size,),
+        dimension_names=["samples"],
+    )
+    root.create_array(
+        call_name,
+        data=np.asarray(genotype, dtype=np.int8),
+        chunks=(2, samples_chunk_size, 2),
+        dimension_names=["variants", "samples", "ploidy"],
+    )
+    return store
+
+
+def test_append_preserves_order_when_destination_is_chunk_aligned():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2"],
+        _make_genotype(2, 2),
+        samples_chunk_size=2,
+    )
+    store2 = _create_minimal_append_store(
+        ["S3", "S4", "S5", "S6"],
+        _make_genotype(2, 4),
+        samples_chunk_size=2,
+    )
+
+    append(store1, store2, io_concurrency=2)
+
+    root = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(
+        root["sample_id"][:], np.array(["S1", "S2", "S3", "S4", "S5", "S6"])
+    )
+    np.testing.assert_array_equal(root["call_genotype"][:, 2:, :], _make_genotype(2, 4))
+
+
+def test_append_fills_partial_destination_chunk_from_incoming_tail():
+    store1 = _create_minimal_append_store(
+        ["S1", "S2", "S3"],
+        _make_genotype(2, 3),
+        samples_chunk_size=2,
+    )
+    incoming = _make_genotype(2, 5)
+    store2 = _create_minimal_append_store(
+        ["I1", "I2", "I3", "I4", "I5"],
+        incoming,
+        samples_chunk_size=2,
+    )
+
+    append(store1, store2, io_concurrency=2)
+
+    root = zarr.open_group(store=store1, mode="r")
+    np.testing.assert_array_equal(
+        root["sample_id"][:],
+        np.array(["S1", "S2", "S3", "I5", "I1", "I2", "I3", "I4"]),
+    )
+    expected = np.concatenate([incoming[:, 4:5, :], incoming[:, :4, :]], axis=1)
+    np.testing.assert_array_equal(root["call_genotype"][:, 3:, :], expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from .utils import (
 @pytest.mark.parametrize(
     ("command", "command_args", "function_name", "expected_args"),
     [
-        ("append", ["left", "right"], "append_function", ("left", "right")),
         (
             "normalise",
             ["left", "right", "out"],
@@ -41,7 +40,7 @@ def test_progress_commands_pass_arguments_and_progress_option(
 ):
     seen = {}
 
-    def fake_function(*args, show_progress=False):
+    def fake_function(*args, show_progress=False, **kwargs):
         seen["args"] = args
         seen["show_progress"] = show_progress
 
@@ -67,7 +66,7 @@ def test_progress_commands_pass_arguments_and_progress_option(
             ["left", "right"],
             "append_function",
             "append",
-            ("transaction-store", "right", True),
+            ("transaction-store", "right"),
         ),
         (
             "remove",
@@ -94,8 +93,11 @@ def test_mutating_icechunk_commands_use_transaction(
         seen["transaction"] = (path, branch, message)
         return FakeTransaction()
 
-    def fake_function(*args, show_progress=False):
-        seen["call"] = (*args, show_progress)
+    def fake_function(*args, show_progress=False, **kwargs):
+        if function_name == "append_function":
+            seen["call"] = args
+        else:
+            seen["call"] = (*args, show_progress)
 
     monkeypatch.setattr(cli, function_name, fake_function)
     monkeypatch.setattr(
@@ -133,6 +135,29 @@ def test_copy_store_to_icechunk_cli_delegates_to_copy_function(monkeypatch):
 
     assert result.exit_code == 0
     assert seen["args"] == ("left", "right")
+
+
+def test_append_cli_passes_io_concurrency(monkeypatch):
+    seen = {}
+
+    def fake_append(vcz1, vcz2, *, io_concurrency=None):
+        seen["args"] = (vcz1, vcz2)
+        seen["io_concurrency"] = io_concurrency
+
+    monkeypatch.setattr(cli, "append_function", fake_append)
+
+    runner = ct.CliRunner()
+    result = runner.invoke(
+        cli.vczstore_main,
+        ["append", "--io-concurrency", "64", "left", "right"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert seen == {
+        "args": ("left", "right"),
+        "io_concurrency": 64,
+    }
 
 
 def test_help_lists_commands_in_natural_order():
@@ -185,7 +210,7 @@ def test_missing_required_arguments_are_rejected(args):
 
 
 def test_cli_reports_operation_value_errors(monkeypatch):
-    def fake_append(vcz1, vcz2, *, show_progress=False):
+    def fake_append(vcz1, vcz2, **kwargs):
         raise ValueError("stores do not line up")
 
     monkeypatch.setattr(cli, "append_function", fake_append)
@@ -204,7 +229,7 @@ def test_append_cli_updates_vcz_store(tmp_path):
     runner = ct.CliRunner()
     result = runner.invoke(
         cli.vczstore_main,
-        ["append", "--no-progress", str(vcz1), str(vcz2)],
+        ["append", str(vcz1), str(vcz2)],
         catch_exceptions=False,
     )
 
@@ -236,7 +261,7 @@ def test_append_cli_reports_real_validation_error(tmp_path):
     runner = ct.CliRunner()
     result = runner.invoke(
         cli.vczstore_main,
-        ["append", "--no-progress", str(vcz1), str(vcz2)],
+        ["append", str(vcz1), str(vcz2)],
     )
 
     assert result.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,19 +137,27 @@ def test_copy_store_to_icechunk_cli_delegates_to_copy_function(monkeypatch):
     assert seen["args"] == ("left", "right")
 
 
-def test_append_cli_passes_io_concurrency(monkeypatch):
+def test_append_cli_passes_io_concurrency_and_direct_copy_flag(monkeypatch):
     seen = {}
 
-    def fake_append(vcz1, vcz2, *, io_concurrency=None):
+    def fake_append(vcz1, vcz2, *, io_concurrency=None, require_direct_copy=False):
         seen["args"] = (vcz1, vcz2)
         seen["io_concurrency"] = io_concurrency
+        seen["require_direct_copy"] = require_direct_copy
 
     monkeypatch.setattr(cli, "append_function", fake_append)
 
     runner = ct.CliRunner()
     result = runner.invoke(
         cli.vczstore_main,
-        ["append", "--io-concurrency", "64", "left", "right"],
+        [
+            "append",
+            "--io-concurrency",
+            "64",
+            "--require-direct-copy",
+            "left",
+            "right",
+        ],
         catch_exceptions=False,
     )
 
@@ -157,6 +165,7 @@ def test_append_cli_passes_io_concurrency(monkeypatch):
     assert seen == {
         "args": ("left", "right"),
         "io_concurrency": 64,
+        "require_direct_copy": True,
     }
 
 

--- a/vczstore/append.py
+++ b/vczstore/append.py
@@ -1,10 +1,13 @@
+import asyncio
 import logging
+import os
+from contextlib import suppress
+from itertools import product
 
 import numpy as np
 import zarr
 from vcztools.utils import array_dims
-
-from vczstore.utils import variant_chunk_slices, variants_progress
+from zarr.core.sync import sync
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +27,13 @@ def _assert_variant_chunk_alignment(arrays, *, variant_chunk_size, operation):
 def _assert_append_arrays_compatible(name, arr1, arr2):
     dims1 = array_dims(arr1)
     dims2 = array_dims(arr2)
+    if dims1 is None or len(dims1) < 2 or tuple(dims1[:2]) != (
+        "variants",
+        "samples",
+    ):
+        raise ValueError(
+            f"append requires {name!r} to use variants/samples dimensions"
+        )
     if dims1 != dims2:
         raise ValueError(
             f"append requires {name!r} to have matching dimensions. "
@@ -46,8 +56,83 @@ def _assert_append_arrays_compatible(name, arr1, arr2):
         )
 
 
-def append(vcz1, vcz2, *, show_progress=False):
+def _assert_can_copy_encoded_chunks(name, arr1, arr2):
+    if arr1.chunks != arr2.chunks:
+        raise ValueError(
+            "direct append requires matching chunks for encoded chunk copy. "
+            f"{name!r} has chunks {arr1.chunks} and {arr2.chunks}"
+        )
+    # Shape changes during append and attributes do not affect encoded chunk bytes.
+    if (
+        {**arr1.metadata.to_dict(), "shape": None, "attributes": None}
+        != {**arr2.metadata.to_dict(), "shape": None, "attributes": None}
+    ):
+        raise ValueError(
+            "direct append requires matching encoded chunk metadata. "
+            f"{name!r} cannot be copied chunk-by-chunk"
+        )
+
+
+async def _copy_encoded_chunks(
+    dst_arr, src_arr, *, src_start, dst_start, count, io_concurrency
+):
+    def chunk_pairs():
+        for variant_chunk in range(src_arr.cdata_shape[0]):
+            for sample_offset in range(count // dst_arr.chunks[1]):
+                for extra_chunk_coords in product(
+                    *[range(n) for n in src_arr.cdata_shape[2:]]
+                ):
+                    src_coords = (
+                        variant_chunk,
+                        src_start // src_arr.chunks[1] + sample_offset,
+                        *extra_chunk_coords,
+                    )
+                    dst_coords = (
+                        variant_chunk,
+                        dst_start // dst_arr.chunks[1] + sample_offset,
+                        *extra_chunk_coords,
+                    )
+                    yield src_coords, dst_coords
+
+    async def copy_chunk(src_coords, dst_coords):
+        src_key = src_arr.store_path / src_arr.metadata.encode_chunk_key(src_coords)
+        dst_key = dst_arr.store_path / dst_arr.metadata.encode_chunk_key(dst_coords)
+        buf = await src_key.get()
+        if buf is None:
+            with suppress(FileNotFoundError):
+                await dst_key.delete()
+        else:
+            await dst_key.set(buf)
+
+    async def wait_for_one(tasks):
+        done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            task.result()
+        return tasks
+
+    tasks = set()
+    try:
+        for src_coords, dst_coords in chunk_pairs():
+            if len(tasks) >= io_concurrency:
+                tasks = await wait_for_one(tasks)
+            tasks.add(asyncio.create_task(copy_chunk(src_coords, dst_coords)))
+        while tasks:
+            # Surface errors as soon as they happen
+            tasks = await wait_for_one(tasks)
+    # Cancel remaining work on error
+    except Exception:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
+def append(vcz1, vcz2, *, io_concurrency=None):
     """Append vcz2 to vcz1 in place"""
+    if io_concurrency is None:
+        io_concurrency = (os.cpu_count() or 1) * 4
+    if io_concurrency < 1:
+        raise ValueError("io_concurrency must be greater than or equal to 1")
     root1 = zarr.open(vcz1, mode="r+")
     root2 = zarr.open(vcz2, mode="r")
 
@@ -60,9 +145,7 @@ def append(vcz1, vcz2, *, show_progress=False):
             f"First has {n_variants1}, second has {n_variants2}"
         )
     for field in ("contig_id", "variant_contig", "variant_position", "variant_allele"):
-        values1 = root1[field][:]
-        values2 = root2[field][:]
-        if np.any(values1 != values2):
+        if not np.array_equal(root1[field][:], root2[field][:]):
             raise ValueError(
                 f"Stores being appended must have same values for field '{field}'"
             )
@@ -77,14 +160,14 @@ def append(vcz1, vcz2, *, show_progress=False):
             arr1 = root1[var]
             arr2 = root2[var]
             _assert_append_arrays_compatible(var, arr1, arr2)
-            call_arrays.append((var, arr1))
+            call_arrays.append((var, arr1, arr2))
     _assert_variant_chunk_alignment(
-        call_arrays,
+        [(var, arr1) for var, arr1, _ in call_arrays],
         variant_chunk_size=root1["variant_contig"].chunks[0],
         operation="append",
     )
     _assert_variant_chunk_alignment(
-        [(var, root2[var]) for var, _ in call_arrays],
+        [(var, arr2) for var, _, arr2 in call_arrays],
         variant_chunk_size=root2["variant_contig"].chunks[0],
         operation="append",
     )
@@ -94,28 +177,78 @@ def append(vcz1, vcz2, *, show_progress=False):
     sample_id2 = root2["sample_id"]
 
     old_num_samples = sample_id1.shape[0]
-    new_num_samples = old_num_samples + sample_id2.shape[0]
-    new_shape = (new_num_samples,)
-    sample_id1.resize(new_shape)
-    sample_id1[old_num_samples:new_num_samples] = sample_id2[:]
+    incoming_num_samples = sample_id2.shape[0]
+    new_num_samples = old_num_samples + incoming_num_samples
+    samples_chunk_size = call_arrays[0][1].chunks[1]
+
+    # Distance from the current sample count to the next sample chunk boundary.
+    gap_count = (-old_num_samples) % samples_chunk_size
+    if gap_count >= incoming_num_samples:
+        gap_count = 0
+
+    direct_count = (
+        (incoming_num_samples - gap_count) // samples_chunk_size
+    ) * samples_chunk_size
+    tail_count = incoming_num_samples - gap_count - direct_count
+
+    if direct_count:
+        for name, arr1, arr2 in call_arrays:
+            sample_chunk_size = arr1.chunks[1]
+            if (
+                direct_count % sample_chunk_size
+                or (old_num_samples + gap_count) % sample_chunk_size
+            ):
+                raise ValueError(
+                    "direct append requires sample chunk-aligned slices for encoded "
+                    f"chunk copy. {name!r} uses sample chunks of size "
+                    f"{sample_chunk_size}"
+                )
+            _assert_can_copy_encoded_chunks(name, arr1, arr2)
+
+    sample_id1.resize((new_num_samples,))
 
     # resize genotype fields
-    for _, arr in call_arrays:
-        if arr.ndim == 2:
-            new_shape = (arr.shape[0], new_num_samples)
-            arr.resize(new_shape)
-        elif arr.ndim == 3:
-            new_shape = (arr.shape[0], new_num_samples, arr.shape[2])
-            arr.resize(new_shape)
-        else:
-            raise ValueError("unsupported number of array_dims")
+    for _, arr, _ in call_arrays:
+        arr.resize((arr.shape[0], new_num_samples, *arr.shape[2:]))
 
-    # append genotype fields
-    with variants_progress(n_variants1, "Append", show_progress) as pbar:
-        for v_sel in variant_chunk_slices(root1):
-            for var in root1.keys():
-                if var.startswith("call_"):
-                    root1[var][v_sel, old_num_samples:new_num_samples, ...] = root2[
-                        var
-                    ][v_sel, ...]
-            pbar.update(v_sel.stop - v_sel.start)
+    # TODO This should probably work in sections for memory friendlyness.
+    def append_rewrite(src_start, dst_start, count):
+        sample_id1[dst_start : dst_start + count] = sample_id2[
+            src_start : src_start + count
+        ]
+        for _, arr1, arr2 in call_arrays:
+            arr1[:, dst_start : dst_start + count, ...] = arr2[
+                :, src_start : src_start + count, ...
+            ]
+
+    def append_direct(src_start, dst_start, count):
+        sample_id1[dst_start : dst_start + count] = sample_id2[
+            src_start : src_start + count
+        ]
+        for _, arr1, arr2 in call_arrays:
+            sync(
+                _copy_encoded_chunks(
+                    arr1,
+                    arr2,
+                    src_start=src_start,
+                    dst_start=dst_start,
+                    count=count,
+                    io_concurrency=io_concurrency,
+                )
+            )
+
+    with zarr.config.set({"async.concurrency": io_concurrency}):
+        if gap_count:
+            # Use incoming tail samples to fill the destination chunk gap, keeping the
+            # remaining incoming prefix sample-chunk aligned for encoded chunk copy.
+            append_rewrite(incoming_num_samples - gap_count, old_num_samples, gap_count)
+
+        if direct_count:
+            append_direct(0, old_num_samples + gap_count, direct_count)
+
+        if tail_count:
+            append_rewrite(
+                direct_count,
+                old_num_samples + gap_count + direct_count,
+                tail_count,
+            )

--- a/vczstore/append.py
+++ b/vczstore/append.py
@@ -27,13 +27,16 @@ def _assert_variant_chunk_alignment(arrays, *, variant_chunk_size, operation):
 def _assert_append_arrays_compatible(name, arr1, arr2):
     dims1 = array_dims(arr1)
     dims2 = array_dims(arr2)
-    if dims1 is None or len(dims1) < 2 or tuple(dims1[:2]) != (
-        "variants",
-        "samples",
-    ):
-        raise ValueError(
-            f"append requires {name!r} to use variants/samples dimensions"
+    if (
+        dims1 is None
+        or len(dims1) < 2
+        or tuple(dims1[:2])
+        != (
+            "variants",
+            "samples",
         )
+    ):
+        raise ValueError(f"append requires {name!r} to use variants/samples dimensions")
     if dims1 != dims2:
         raise ValueError(
             f"append requires {name!r} to have matching dimensions. "
@@ -56,27 +59,47 @@ def _assert_append_arrays_compatible(name, arr1, arr2):
         )
 
 
-def _assert_can_copy_encoded_chunks(name, arr1, arr2):
+def _copy_encoded_chunks_error(name, arr1, arr2):
     if arr1.chunks != arr2.chunks:
-        raise ValueError(
+        return (
             "direct append requires matching chunks for encoded chunk copy. "
             f"{name!r} has chunks {arr1.chunks} and {arr2.chunks}"
         )
     # Shape changes during append and attributes do not affect encoded chunk bytes.
-    if (
-        {**arr1.metadata.to_dict(), "shape": None, "attributes": None}
-        != {**arr2.metadata.to_dict(), "shape": None, "attributes": None}
-    ):
-        raise ValueError(
+    if {**arr1.metadata.to_dict(), "shape": None, "attributes": None} != {
+        **arr2.metadata.to_dict(),
+        "shape": None,
+        "attributes": None,
+    }:
+        return (
             "direct append requires matching encoded chunk metadata. "
             f"{name!r} cannot be copied chunk-by-chunk"
         )
+    return None
 
 
 async def _copy_encoded_chunks(
     dst_arr, src_arr, *, src_start, dst_start, count, io_concurrency
 ):
-    def chunk_pairs():
+    async def copy_chunk(src_coords, dst_coords):
+        src_key = src_arr.store_path / src_arr.metadata.encode_chunk_key(src_coords)
+        dst_key = dst_arr.store_path / dst_arr.metadata.encode_chunk_key(dst_coords)
+        buf = await src_key.get()
+        if buf is None:
+            # Sparse source chunks must clear any stale destination chunk.
+            with suppress(FileNotFoundError):
+                await dst_key.delete()
+        else:
+            await dst_key.set(buf)
+
+    async def wait_for_one(tasks):
+        done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            task.result()
+        return tasks
+
+    tasks = set()
+    try:
         for variant_chunk in range(src_arr.cdata_shape[0]):
             for sample_offset in range(count // dst_arr.chunks[1]):
                 for extra_chunk_coords in product(
@@ -92,30 +115,9 @@ async def _copy_encoded_chunks(
                         dst_start // dst_arr.chunks[1] + sample_offset,
                         *extra_chunk_coords,
                     )
-                    yield src_coords, dst_coords
-
-    async def copy_chunk(src_coords, dst_coords):
-        src_key = src_arr.store_path / src_arr.metadata.encode_chunk_key(src_coords)
-        dst_key = dst_arr.store_path / dst_arr.metadata.encode_chunk_key(dst_coords)
-        buf = await src_key.get()
-        if buf is None:
-            with suppress(FileNotFoundError):
-                await dst_key.delete()
-        else:
-            await dst_key.set(buf)
-
-    async def wait_for_one(tasks):
-        done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        for task in done:
-            task.result()
-        return tasks
-
-    tasks = set()
-    try:
-        for src_coords, dst_coords in chunk_pairs():
-            if len(tasks) >= io_concurrency:
-                tasks = await wait_for_one(tasks)
-            tasks.add(asyncio.create_task(copy_chunk(src_coords, dst_coords)))
+                    if len(tasks) >= io_concurrency:
+                        tasks = await wait_for_one(tasks)
+                    tasks.add(asyncio.create_task(copy_chunk(src_coords, dst_coords)))
         while tasks:
             # Surface errors as soon as they happen
             tasks = await wait_for_one(tasks)
@@ -127,7 +129,7 @@ async def _copy_encoded_chunks(
         raise
 
 
-def append(vcz1, vcz2, *, io_concurrency=None):
+def append(vcz1, vcz2, *, io_concurrency=None, require_direct_copy=False):
     """Append vcz2 to vcz1 in place"""
     if io_concurrency is None:
         io_concurrency = (os.cpu_count() or 1) * 4
@@ -179,31 +181,22 @@ def append(vcz1, vcz2, *, io_concurrency=None):
     old_num_samples = sample_id1.shape[0]
     incoming_num_samples = sample_id2.shape[0]
     new_num_samples = old_num_samples + incoming_num_samples
-    samples_chunk_size = call_arrays[0][1].chunks[1]
 
-    # Distance from the current sample count to the next sample chunk boundary.
-    gap_count = (-old_num_samples) % samples_chunk_size
-    if gap_count >= incoming_num_samples:
-        gap_count = 0
-
-    direct_count = (
-        (incoming_num_samples - gap_count) // samples_chunk_size
-    ) * samples_chunk_size
-    tail_count = incoming_num_samples - gap_count - direct_count
-
-    if direct_count:
+    if require_direct_copy:
         for name, arr1, arr2 in call_arrays:
             sample_chunk_size = arr1.chunks[1]
             if (
-                direct_count % sample_chunk_size
-                or (old_num_samples + gap_count) % sample_chunk_size
+                old_num_samples % sample_chunk_size
+                or incoming_num_samples % sample_chunk_size
             ):
                 raise ValueError(
-                    "direct append requires sample chunk-aligned slices for encoded "
-                    f"chunk copy. {name!r} uses sample chunks of size "
+                    "direct-only append requires the destination sample count and "
+                    "incoming sample count to be sample chunk-aligned. "
+                    f"{name!r} uses sample chunks of size "
                     f"{sample_chunk_size}"
                 )
-            _assert_can_copy_encoded_chunks(name, arr1, arr2)
+            if error := _copy_encoded_chunks_error(name, arr1, arr2):
+                raise ValueError(error)
 
     sample_id1.resize((new_num_samples,))
 
@@ -211,44 +204,34 @@ def append(vcz1, vcz2, *, io_concurrency=None):
     for _, arr, _ in call_arrays:
         arr.resize((arr.shape[0], new_num_samples, *arr.shape[2:]))
 
-    # TODO This should probably work in sections for memory friendlyness.
-    def append_rewrite(src_start, dst_start, count):
-        sample_id1[dst_start : dst_start + count] = sample_id2[
-            src_start : src_start + count
-        ]
-        for _, arr1, arr2 in call_arrays:
-            arr1[:, dst_start : dst_start + count, ...] = arr2[
-                :, src_start : src_start + count, ...
-            ]
-
-    def append_direct(src_start, dst_start, count):
-        sample_id1[dst_start : dst_start + count] = sample_id2[
-            src_start : src_start + count
-        ]
-        for _, arr1, arr2 in call_arrays:
-            sync(
-                _copy_encoded_chunks(
-                    arr1,
-                    arr2,
-                    src_start=src_start,
-                    dst_start=dst_start,
-                    count=count,
-                    io_concurrency=io_concurrency,
-                )
-            )
+    sample_id1[old_num_samples:new_num_samples] = sample_id2[:]
 
     with zarr.config.set({"async.concurrency": io_concurrency}):
-        if gap_count:
-            # Use incoming tail samples to fill the destination chunk gap, keeping the
-            # remaining incoming prefix sample-chunk aligned for encoded chunk copy.
-            append_rewrite(incoming_num_samples - gap_count, old_num_samples, gap_count)
+        for name, arr1, arr2 in call_arrays:
+            sample_chunk_size = arr1.chunks[1]
+            if (
+                old_num_samples % sample_chunk_size == 0
+                and _copy_encoded_chunks_error(name, arr1, arr2) is None
+            ):
+                direct_count = (
+                    incoming_num_samples // sample_chunk_size
+                ) * sample_chunk_size
+            else:
+                direct_count = 0
 
-        if direct_count:
-            append_direct(0, old_num_samples + gap_count, direct_count)
+            if direct_count:
+                sync(
+                    _copy_encoded_chunks(
+                        arr1,
+                        arr2,
+                        src_start=0,
+                        dst_start=old_num_samples,
+                        count=direct_count,
+                        io_concurrency=io_concurrency,
+                    )
+                )
 
-        if tail_count:
-            append_rewrite(
-                direct_count,
-                old_num_samples + gap_count + direct_count,
-                tail_count,
-            )
+            if direct_count < incoming_num_samples:
+                arr1[:, old_num_samples + direct_count : new_num_samples, ...] = arr2[
+                    :, direct_count:incoming_num_samples, ...
+                ]

--- a/vczstore/cli.py
+++ b/vczstore/cli.py
@@ -55,7 +55,15 @@ zarr_backend_storage = click.option(
     show_default="4 x CPU cores",
     help="Maximum concurrent chunk copy operations.",
 )
-def append(vcz1, vcz2, zarr_backend_storage, io_concurrency):
+@click.option(
+    "--require-direct-copy",
+    is_flag=True,
+    help=(
+        "Fail unless the append can be performed entirely by encoded chunk copy. "
+        "This requires a sample chunk-aligned destination and incoming sample count."
+    ),
+)
+def append(vcz1, vcz2, zarr_backend_storage, io_concurrency, require_direct_copy):
     """Append vcz2 to vcz1 in place"""
     if zarr_backend_storage == "icechunk":
         from vczstore.icechunk_utils import icechunk_transaction
@@ -69,6 +77,7 @@ def append(vcz1, vcz2, zarr_backend_storage, io_concurrency):
             vcz1,
             vcz2,
             io_concurrency=io_concurrency,
+            require_direct_copy=require_direct_copy,
         )
 
 

--- a/vczstore/cli.py
+++ b/vczstore/cli.py
@@ -47,9 +47,15 @@ zarr_backend_storage = click.option(
 @click.command()
 @click.argument("vcz1", type=click.Path())
 @click.argument("vcz2", type=click.Path())
-@progress
 @zarr_backend_storage
-def append(vcz1, vcz2, progress, zarr_backend_storage):
+@click.option(
+    "--io-concurrency",
+    type=click.IntRange(min=1),
+    default=None,
+    show_default="4 x CPU cores",
+    help="Maximum concurrent chunk copy operations.",
+)
+def append(vcz1, vcz2, zarr_backend_storage, io_concurrency):
     """Append vcz2 to vcz1 in place"""
     if zarr_backend_storage == "icechunk":
         from vczstore.icechunk_utils import icechunk_transaction
@@ -58,7 +64,12 @@ def append(vcz1, vcz2, progress, zarr_backend_storage):
     else:
         cm = nullcontext(vcz1)
     with cm as vcz1:
-        call_or_error(append_function, vcz1, vcz2, show_progress=progress)
+        call_or_error(
+            append_function,
+            vcz1,
+            vcz2,
+            io_concurrency=io_concurrency,
+        )
 
 
 @click.command()


### PR DESCRIPTION
Make append copy encoded chunks when possible.

This includes the shuffle logic at https://github.com/sgkit-dev/vczstore/compare/main...benjeffery-ofh:append-reorder-direct-poc?expand=1#diff-9c7eafd729712c5d03aec28df2ba1a8811fb40c1fa654951b4dfe392af0c00c9R180 which is a small part of the PR and can be backed out if needed. Without it the direct copy can only work if the existing store ends at a chunk boundary.

The other candidate append PRs took around 20min to append 100k whether on a boundary or not. This PR gets that down to a 65s on the boundary:

| Case | Branch | Samples | Wall time | CPU time |
|---|---|---:|---:|---:|
| Off-boundary | `bench-off-boundary-20260429-114624` | `600414 -> 700414` | `252.699s` | `2330.220s` |
| On-boundary | `bench-on-boundary-20260429-114624` | `600000 -> 700000` | `65.000s` | `237.492s` |
