### PR TITLE
Asynchronous, bounded version of `store_copy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
   {name = "sgkit Developers", email = "project@sgkit.dev"},
 ]
 dependencies = [
+  "aiostream>=0.7.1",
   "bio2zarr @ git+https://github.com/sgkit-dev/bio2zarr.git",
   "click>=8.2.0",
   "more_itertools",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,8 +73,9 @@ def test_commands_pass_arguments_and_options(
 def test_copy_store_to_icechunk_cli_delegates_to_copy_function(monkeypatch):
     seen = {}
 
-    def fake_copy_store_to_icechunk(source, dest):
+    def fake_copy_store_to_icechunk(source, dest, *, io_concurrency=None):
         seen["args"] = (source, dest)
+        seen["io_concurrency"] = io_concurrency
 
     monkeypatch.setattr(
         "vczstore.utils.copy_store_to_icechunk", fake_copy_store_to_icechunk
@@ -83,12 +84,15 @@ def test_copy_store_to_icechunk_cli_delegates_to_copy_function(monkeypatch):
     runner = ct.CliRunner()
     result = runner.invoke(
         cli.vczstore_main,
-        ["copy-store-to-icechunk", "left", "right"],
+        ["copy-store-to-icechunk", "--io-concurrency", "64", "left", "right"],
         catch_exceptions=False,
     )
 
     assert result.exit_code == 0
-    assert seen["args"] == ("left", "right")
+    assert seen == {
+        "args": ("left", "right"),
+        "io_concurrency": 64,
+    }
 
 
 def test_append_cli_passes_io_concurrency_and_direct_copy_flag(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,15 @@
-import pytest
+import asyncio
 
-from vczstore.utils import merge_with
+import numpy as np
+import pytest
+import zarr
+
+from vczstore.utils import (
+    copy_store,
+    copy_store_async,
+    merge_with,
+    split_metadata_and_data_keys,
+)
 
 
 def eq(a, b):
@@ -57,3 +66,141 @@ def test_merge_with_combine_called():
     result = merge_with(["x", "y"], ["y", "z"], equiv=eq, combine=record_combine)
     assert result == ["x", "y+y", "z"]
     assert combined == [("y", "y")]
+
+
+class FakeSourceStore:
+    def __init__(self, data, delay=0.01, failing_key=None):
+        self.data = data
+        self.delay = delay
+        self.failing_key = failing_key
+        self.active_gets = 0
+        self.max_active_gets = 0
+
+    async def list(self):
+        for key in self.data:
+            yield key
+
+    async def get(self, key, prototype):
+        self.active_gets += 1
+        self.max_active_gets = max(self.max_active_gets, self.active_gets)
+        try:
+            await asyncio.sleep(self.delay)
+            if key == self.failing_key:
+                raise RuntimeError(f"get failed for {key}")
+            return prototype.buffer.from_bytes(self.data[key])
+        finally:
+            self.active_gets -= 1
+
+
+class FakeDestStore:
+    def __init__(self, metadata_keys, delay=0.01, failing_key=None):
+        self.delay = delay
+        self.failing_key = failing_key
+        self.metadata_keys = set(metadata_keys)
+        self.seen = []
+        self.values = {}
+        self.data_before_metadata = False
+
+    async def set(self, key, value):
+        if key not in self.metadata_keys and not self.metadata_keys.issubset(self.seen):
+            self.data_before_metadata = True
+        await asyncio.sleep(self.delay)
+        if key == self.failing_key:
+            raise RuntimeError(f"set failed for {key}")
+        self.seen.append(key)
+        self.values[key] = value.to_bytes()
+
+
+def test_split_metadata_and_data_keys_puts_metadata_before_chunks():
+    keys = ["sample/c/0", "sample/zarr.json", "zarr.json", "sample/c/1"]
+
+    metadata_keys, data_keys = split_metadata_and_data_keys(keys)
+
+    assert metadata_keys == ["zarr.json", "sample/zarr.json"]
+    assert data_keys == ["sample/c/1", "sample/c/0"]
+
+
+def test_copy_store_async_uses_bounded_concurrency_and_metadata_barrier():
+    keys = ["sample/c/0", "sample/zarr.json", "zarr.json", "sample/c/1", "sample/c/2"]
+    data = {key: key.encode() for key in keys}
+    metadata_keys, _ = split_metadata_and_data_keys(keys)
+    source = FakeSourceStore(data)
+    dest = FakeDestStore(metadata_keys)
+
+    asyncio.run(copy_store_async(source, dest, io_concurrency=2))
+
+    assert source.max_active_gets <= 2
+    assert dest.data_before_metadata is False
+    assert dest.seen[: len(metadata_keys)] == metadata_keys
+    assert dest.values == data
+
+
+def test_copy_store_async_does_not_start_data_writes_after_metadata_failure():
+    keys = ["sample/c/0", "sample/zarr.json", "zarr.json", "sample/c/1"]
+    data = {key: key.encode() for key in keys}
+    metadata_keys, _ = split_metadata_and_data_keys(keys)
+    source = FakeSourceStore(data)
+    dest = FakeDestStore(metadata_keys, failing_key="sample/zarr.json")
+
+    with pytest.raises(RuntimeError, match="set failed"):
+        asyncio.run(copy_store_async(source, dest, io_concurrency=2))
+
+    assert dest.data_before_metadata is False
+    assert "sample/c/0" not in dest.seen
+    assert "sample/c/1" not in dest.seen
+
+
+def test_copy_store_async_propagates_source_failures():
+    keys = ["sample/c/0", "sample/zarr.json", "zarr.json", "sample/c/1"]
+    data = {key: key.encode() for key in keys}
+    metadata_keys, _ = split_metadata_and_data_keys(keys)
+    source = FakeSourceStore(data, failing_key="sample/c/1")
+    dest = FakeDestStore(metadata_keys)
+
+    with pytest.raises(RuntimeError, match="get failed"):
+        asyncio.run(copy_store_async(source, dest, io_concurrency=2))
+
+
+def test_copy_store_async_propagates_destination_failures():
+    keys = ["sample/c/0", "sample/zarr.json", "zarr.json", "sample/c/1"]
+    data = {key: key.encode() for key in keys}
+    metadata_keys, _ = split_metadata_and_data_keys(keys)
+    source = FakeSourceStore(data)
+    dest = FakeDestStore(metadata_keys, failing_key="sample/c/1")
+
+    with pytest.raises(RuntimeError, match="set failed"):
+        asyncio.run(copy_store_async(source, dest, io_concurrency=2))
+
+
+@pytest.mark.parametrize("io_concurrency", [1, 4])
+def test_copy_store_wrapper_produces_identical_contents(io_concurrency):
+    source = zarr.storage.MemoryStore()
+    dest = zarr.storage.MemoryStore()
+
+    root = zarr.create_group(store=source)
+    root.attrs["dataset"] = "example"
+    root.create_array(
+        "variant_position",
+        data=np.array([1, 2, 3], dtype=np.int32),
+        chunks=(2,),
+        dimension_names=["variants"],
+        compressors=None,
+        filters=None,
+    )
+    root.create_array(
+        "call_genotype",
+        data=np.array([[[0, 1]], [[1, 0]], [[0, 0]]], dtype=np.int8),
+        chunks=(2, 1, 2),
+        dimension_names=["variants", "samples", "ploidy"],
+        compressors=None,
+        filters=None,
+    )
+
+    copy_store(source, dest, io_concurrency=io_concurrency)
+
+    copied = zarr.open_group(store=dest, mode="r")
+    np.testing.assert_array_equal(
+        copied["variant_position"][:], root["variant_position"][:]
+    )
+    np.testing.assert_array_equal(copied["call_genotype"][:], root["call_genotype"][:])
+    assert copied.attrs.asdict() == root.attrs.asdict()

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiostream"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/65/b9b69695702b76a878c9879f2ee80cefce75bc5cb864fc100460bc1c5380/aiostream-0.7.1.tar.gz", hash = "sha256:272aaa0d8f83beb906f5aa9022bb59046bb7a103fa3770f807c31f918595acf6", size = 44059, upload-time = "2025-10-13T20:02:06.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a0/d7c6ca304140f3f49987d710e15bc164248924a35d8cdfac2f6e87fca041/aiostream-0.7.1-py3-none-any.whl", hash = "sha256:ea8739e9158ee6a606b3feedf3762721c3507344e540d09a10984c5e88a13b37", size = 41416, upload-time = "2025-10-13T20:02:05.535Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1270,6 +1282,7 @@ all = [
 name = "vczstore"
 source = { editable = "." }
 dependencies = [
+    { name = "aiostream" },
     { name = "bio2zarr" },
     { name = "click" },
     { name = "more-itertools" },
@@ -1319,6 +1332,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiostream", specifier = ">=0.7.1" },
     { name = "bio2zarr", git = "https://github.com/sgkit-dev/bio2zarr.git" },
     { name = "click", specifier = ">=8.2.0" },
     { name = "hypothesis", marker = "extra == 'icechunk'" },

--- a/vczstore/cli.py
+++ b/vczstore/cli.py
@@ -57,19 +57,21 @@ variant_chunks_in_batch = click.option(
     help="The number of variant chunks to process in each batch",
 )
 
-
-@click.command()
-@click.argument("vcz1", type=click.Path())
-@click.argument("vcz2", type=click.Path())
-@verbose
-@backend_storage
-@click.option(
+io_concurrency = click.option(
     "--io-concurrency",
     type=click.IntRange(min=1),
     default=None,
     show_default="4 x CPU cores",
     help="Maximum concurrent chunk copy operations.",
 )
+
+
+@click.command()
+@click.argument("vcz1", type=click.Path())
+@click.argument("vcz2", type=click.Path())
+@verbose
+@backend_storage
+@io_concurrency
 @click.option(
     "--require-direct-copy",
     is_flag=True,
@@ -165,14 +167,17 @@ def remove(vcz, sample_id, variant_chunks_in_batch, verbose, progress, backend_s
 @click.argument("vcz1", type=click.Path())
 @click.argument("vcz2", type=click.Path())
 @verbose
-def copy_store_to_icechunk(vcz1, vcz2, verbose):
+@io_concurrency
+def copy_store_to_icechunk(vcz1, vcz2, verbose, io_concurrency):
     """Copy a Zarr store to a new Icechunk store"""
     from vczstore.utils import (
         copy_store_to_icechunk as copy_store_to_icechunk_function,
     )
 
     setup_logging(verbose)
-    call_or_error(copy_store_to_icechunk_function, vcz1, vcz2)
+    call_or_error(
+        copy_store_to_icechunk_function, vcz1, vcz2, io_concurrency=io_concurrency
+    )
 
 
 @click.group(cls=NaturalOrderGroup, name="vczstore")

--- a/vczstore/utils.py
+++ b/vczstore/utils.py
@@ -1,13 +1,20 @@
+import os
 from collections.abc import Callable
 from contextlib import contextmanager
 from typing import Any
 
 import tqdm
+from aiostream import stream
 from bio2zarr.vcf_utils import ceildiv
 from vcztools.constants import FLOAT32_MISSING, INT_MISSING, STR_MISSING
 from vcztools.utils import make_icechunk_storage
+from zarr.core.buffer.core import default_buffer_prototype
 from zarr.core.sync import sync
 from zarr.storage._common import make_store
+
+ZARR_METADATA_FILENAMES = frozenset(
+    ("zarr.json", ".zarray", ".zattrs", ".zgroup", ".zmetadata")
+)
 
 
 def missing_val(arr):
@@ -45,26 +52,64 @@ def progress_bar(total, title, show_progress=False, unit="vars"):
     )
 
 
-# inspired by commit f3c123d3a2a94b7f14bc995e3897ee6acc9acbd1 in zarr-python
-def copy_store(source, dest, array_keys=None):
-    from zarr.core.buffer.core import default_buffer_prototype
-    from zarr.testing.stateful import SyncStoreWrapper
+def is_metadata_key(key):
+    return key.rsplit("/", 1)[-1] in ZARR_METADATA_FILENAMES
 
-    # ensure source and dest are both stores
+
+def split_metadata_and_data_keys(keys):
+    ordered_keys = sorted(keys, reverse=True)
+    metadata_keys = []
+    data_keys = []
+    for key in ordered_keys:
+        if is_metadata_key(key):
+            metadata_keys.append(key)
+        else:
+            data_keys.append(key)
+    return metadata_keys, data_keys
+
+
+async def copy_store_async(source, dest, *, array_keys=None, io_concurrency):
+    source_keys = [key async for key in source.list()]
+
+    if array_keys is not None:
+        source_keys = [
+            source_key
+            for source_key in source_keys
+            if source_key.split("/")[0] in array_keys
+        ]
+
+    metadata_keys, data_keys = split_metadata_and_data_keys(source_keys)
+    prototype = default_buffer_prototype()
+
+    async def _copy_one_key(key):
+        buffer = await source.get(key, prototype=prototype)
+        if buffer is None:
+            raise FileNotFoundError(key)
+        await dest.set(key, buffer)
+
+    for key in metadata_keys:
+        await _copy_one_key(key)
+
+    await stream.map(
+        stream.iterate(data_keys), _copy_one_key, task_limit=io_concurrency
+    )
+
+
+def copy_store(source, dest, *, array_keys=None, io_concurrency=None):
+    if io_concurrency is None:
+        io_concurrency = (os.cpu_count() or 1) * 4
+    if io_concurrency < 1:
+        raise ValueError("io_concurrency must be greater than or equal to 1")
     source = sync(make_store(source))
     dest = sync(make_store(dest))
-
-    s = SyncStoreWrapper(source)
-    d = SyncStoreWrapper(dest)
-    # need reverse=True to create zarr.json before chunks (otherwise icechunk complains)
-    for source_key in sorted(s.list(), reverse=True):
-        if array_keys is not None and source_key.split("/")[0] not in array_keys:
-            continue
-        buffer = s.get(source_key, default_buffer_prototype())
-        d.set(source_key, buffer)
+    sync(
+        copy_store_async(
+            source, dest, array_keys=array_keys, io_concurrency=io_concurrency
+        )
+    )
 
 
-def copy_store_to_icechunk(source, dest):
+def copy_store_to_icechunk(source, dest, *, io_concurrency=None):
     """Copy a Zarr store to a new Icechunk store."""
     from icechunk import Repository
 
@@ -72,7 +117,7 @@ def copy_store_to_icechunk(source, dest):
     repo = Repository.create(icechunk_storage)
 
     with repo.transaction("main", message="create") as dest:
-        copy_store(source, dest)
+        copy_store(source, dest, io_concurrency=io_concurrency)
 
 
 @contextmanager


### PR DESCRIPTION
Tested on a single sample VCZ with 700K variants, copying to Azure Icechunk goes from 58s to 7s (wall time).

BTW this adds `aiostream` as a dependency for bounding the IO concurrency. I have used this library extensively in Cubed, and am happy with it.