### PR TITLE
Fix `copy_store` to work in case of no chunks

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -122,6 +122,18 @@ def test_split_metadata_and_data_keys_puts_metadata_before_chunks():
     assert data_keys == ["sample/c/1", "sample/c/0"]
 
 
+def test_copy_store_async_no_chunks():
+    keys = ["sample/zarr.json", "zarr.json"]
+    data = {key: key.encode() for key in keys}
+    metadata_keys, _ = split_metadata_and_data_keys(keys)
+    source = FakeSourceStore(data)
+    dest = FakeDestStore(metadata_keys)
+
+    asyncio.run(copy_store_async(source, dest, io_concurrency=2))
+
+    assert dest.values == data
+
+
 def test_copy_store_async_uses_bounded_concurrency_and_metadata_barrier():
     keys = ["sample/c/0", "sample/zarr.json", "zarr.json", "sample/c/1", "sample/c/2"]
     data = {key: key.encode() for key in keys}

--- a/vczstore/utils.py
+++ b/vczstore/utils.py
@@ -90,9 +90,10 @@ async def copy_store_async(source, dest, *, array_keys=None, io_concurrency):
     for key in metadata_keys:
         await _copy_one_key(key)
 
-    await stream.map(
-        stream.iterate(data_keys), _copy_one_key, task_limit=io_concurrency
-    )
+    if len(data_keys) > 0:
+        await stream.map(
+            stream.iterate(data_keys), _copy_one_key, task_limit=io_concurrency
+        )
 
 
 def copy_store(source, dest, *, array_keys=None, io_concurrency=None):


### PR DESCRIPTION
This can happen if there are no samples for example.