### PR TITLE
Rechunk

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import click.testing as ct
 import pytest
+from vcztools.utils import open_zarr
 
 from vczstore import cli
 
@@ -138,6 +139,7 @@ def test_help_lists_commands_in_natural_order():
         "append",
         "create",
         "normalise",
+        "rechunk",
         "remove",
         "copy-store-to-icechunk",
     ]
@@ -147,6 +149,7 @@ def test_help_lists_commands_in_natural_order():
     ("command", "command_args"),
     [
         ("append", ["left", "right"]),
+        ("rechunk", ["store", "variant_contig", "4"]),
         ("remove", ["store", "S1"]),
     ],
 )
@@ -167,6 +170,7 @@ def test_invalid_zarr_backend_storage_is_rejected(command, command_args):
     [
         ["append", "only-one-store"],
         ["normalise", "left", "right"],
+        ["rechunk", "store", "variant_contig"],
         ["remove", "store"],
         ["copy-store-to-icechunk", "only-one-store"],
     ],
@@ -222,6 +226,60 @@ def test_remove_cli_updates_vcz_store(tmp_path):
     vcztools_out, _ = run_vcztools(f"query -l {vcz}")
     assert vcztools_out.strip() == "NA00001\nNA00003"
     check_removed_sample(vcz, "NA00002")
+
+
+def test_rechunk_cli_passes_arguments(monkeypatch):
+    seen = {}
+
+    def fake_rechunk(
+        vcz, variants_array_name, variants_chunk_size, *, backend_storage=None
+    ):
+        seen["args"] = (vcz, variants_array_name, variants_chunk_size)
+        seen["backend_storage"] = backend_storage
+
+    monkeypatch.setattr(cli, "rechunk_function", fake_rechunk)
+
+    runner = ct.CliRunner()
+    result = runner.invoke(
+        cli.vczstore_main,
+        ["rechunk", "--backend-storage", "icechunk", "store", "variant_contig", "4"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert seen == {
+        "args": ("store", "variant_contig", 4),
+        "backend_storage": "icechunk",
+    }
+
+
+@pytest.mark.parametrize(
+    ("backend_storage", "zarr_format"),
+    [(None, None), ("icechunk", 3)],
+)
+def test_rechunk_cli_updates_vcz_store(tmp_path, backend_storage, zarr_format):
+    vcz = convert_vcf_to_vcz(
+        "sample.vcf.gz",
+        tmp_path,
+        variants_chunk_size=2,
+        zarr_format=zarr_format,
+        backend_storage=backend_storage,
+    )
+    backend_storage_args = (
+        ["--backend-storage", backend_storage] if backend_storage else []
+    )
+
+    runner = ct.CliRunner()
+    result = runner.invoke(
+        cli.vczstore_main,
+        ["rechunk", *backend_storage_args, str(vcz), "variant_position", "4"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    root = open_zarr(vcz, backend_storage=backend_storage)
+    assert root["variant_position"].chunks[0] == 4
+    assert root["call_genotype"].chunks[0] == 2
 
 
 def test_append_cli_reports_real_validation_error(tmp_path):

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -1,15 +1,10 @@
-import pathlib
-
 from vcztools.utils import open_zarr
 
 from tests.utils import make_vcz
 from vczstore.rechunk import rechunk
-from vczstore.utils import copy_store_to_icechunk
 
 
-def test_rechunk(
-    tmpdir,
-):
+def test_rechunk():
     vcz = make_vcz(
         variant_contig=[0, 0, 0, 0],
         variant_position=[1, 2, 3, 4],
@@ -29,18 +24,10 @@ def test_rechunk(
         variants_chunk_size=2,
     )
 
-    ic_tmp_path = pathlib.Path(tmpdir) / "icechunk"
-    ic_tmp_path.mkdir()
-    vcz_ic = pathlib.Path(ic_tmp_path) / "store.vcz"
-    copy_store_to_icechunk(vcz, vcz_ic)
+    rechunk(vcz, "variant_contig", 4)
 
-    rechunk(vcz_ic, "variant_contig", 4, backend_storage="icechunk")
-
-    root = open_zarr(vcz_ic, backend_storage="icechunk")
+    root = open_zarr(vcz)
     assert root["variant_contig"].chunks[0] == 4
     assert root["variant_position"].chunks[0] == 2
     assert root["variant_allele"].chunks[0] == 2
     assert root["call_genotype"].chunks[0] == 2
-
-    # check deleted variant is not in root
-    assert "variant_contig_delete" not in root

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -1,0 +1,43 @@
+import pathlib
+
+from vcztools.utils import open_zarr
+
+from tests.utils import make_vcz
+from vczstore.rechunk import rechunk
+from vczstore.utils import copy_store_to_icechunk
+
+
+def test_rechunk(
+    tmpdir,
+):
+    vcz = make_vcz(
+        variant_contig=[0, 0, 0, 0],
+        variant_position=[1, 2, 3, 4],
+        alleles=[
+            ["A", "T"],
+            ["A", "C"],
+            ["A", "C"],
+            ["A", "G"],
+        ],
+        sample_id=["S1", "S2"],
+        call_genotype=[
+            [[0, 0], [1, 0]],
+            [[0, 1], [0, 0]],
+            [[0, 0], [1, 1]],
+            [[1, 1], [0, 1]],
+        ],
+        variants_chunk_size=2,
+    )
+
+    ic_tmp_path = pathlib.Path(tmpdir) / "icechunk"
+    ic_tmp_path.mkdir()
+    vcz_ic = pathlib.Path(ic_tmp_path) / "store.vcz"
+    copy_store_to_icechunk(vcz, vcz_ic)
+
+    rechunk(vcz_ic, "variant_contig", 4)
+
+    root = open_zarr(vcz_ic, backend_storage="icechunk")
+    assert root["variant_contig"].chunks[0] == 4
+    assert root["variant_position"].chunks[0] == 2
+    assert root["variant_allele"].chunks[0] == 2
+    assert root["call_genotype"].chunks[0] == 2

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -34,10 +34,13 @@ def test_rechunk(
     vcz_ic = pathlib.Path(ic_tmp_path) / "store.vcz"
     copy_store_to_icechunk(vcz, vcz_ic)
 
-    rechunk(vcz_ic, "variant_contig", 4)
+    rechunk(vcz_ic, "variant_contig", 4, backend_storage="icechunk")
 
     root = open_zarr(vcz_ic, backend_storage="icechunk")
     assert root["variant_contig"].chunks[0] == 4
     assert root["variant_position"].chunks[0] == 2
     assert root["variant_allele"].chunks[0] == 2
     assert root["call_genotype"].chunks[0] == 2
+
+    # check deleted variant is not in root
+    assert "variant_contig_delete" not in root

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -1,11 +1,12 @@
+import pytest
 from vcztools.utils import open_zarr
 
 from tests.utils import make_vcz
 from vczstore.rechunk import rechunk
 
 
-def test_rechunk():
-    vcz = make_vcz(
+def make_simple_vcz(variants_chunk_size=2):
+    return make_vcz(
         variant_contig=[0, 0, 0, 0],
         variant_position=[1, 2, 3, 4],
         alleles=[
@@ -21,8 +22,12 @@ def test_rechunk():
             [[0, 0], [1, 1]],
             [[1, 1], [0, 1]],
         ],
-        variants_chunk_size=2,
+        variants_chunk_size=variants_chunk_size,
     )
+
+
+def test_rechunk():
+    vcz = make_simple_vcz()
 
     rechunk(vcz, "variant_contig", 4)
 
@@ -31,3 +36,15 @@ def test_rechunk():
     assert root["variant_position"].chunks[0] == 2
     assert root["variant_allele"].chunks[0] == 2
     assert root["call_genotype"].chunks[0] == 2
+
+
+def test_rechunk_no_variants_axis():
+    vcz = make_simple_vcz()
+    with pytest.raises(ValueError, match="Array 'contig_id' does not have variants"):
+        rechunk(vcz, "contig_id", 4)
+
+
+def test_rechunk_not_multiple_of_min_chunk_size():
+    vcz = make_simple_vcz()
+    with pytest.raises(ValueError, match="not an exact multiple"):
+        rechunk(vcz, "variant_contig", 3)

--- a/vczstore/cli.py
+++ b/vczstore/cli.py
@@ -4,6 +4,7 @@ import coloredlogs
 from vczstore.append import append as append_function
 from vczstore.create import create as create_function
 from vczstore.normalise import normalise as normalise_function
+from vczstore.rechunk import rechunk as rechunk_function
 from vczstore.remove import remove as remove_function
 
 
@@ -153,6 +154,25 @@ def normalise(
 
 @click.command()
 @click.argument("vcz", type=click.Path())
+@click.argument("variants_array_name", type=str)
+@click.argument("variants_chunk_size", type=click.IntRange(min=1))
+@verbose
+@backend_storage
+def rechunk(vcz, variants_array_name, variants_chunk_size, verbose, backend_storage):
+    """Rechunk a variants array with a larger variants chunk size that is
+    an exact multiple of the min variants chunk size"""
+    setup_logging(verbose)
+    call_or_error(
+        rechunk_function,
+        vcz,
+        variants_array_name,
+        variants_chunk_size,
+        backend_storage=backend_storage,
+    )
+
+
+@click.command()
+@click.argument("vcz", type=click.Path())
 @click.argument("sample_id", type=str)
 @variant_chunks_in_batch
 @verbose
@@ -197,5 +217,6 @@ def vczstore_main():
 vczstore_main.add_command(append)
 vczstore_main.add_command(create)
 vczstore_main.add_command(normalise)
+vczstore_main.add_command(rechunk)
 vczstore_main.add_command(remove)
 vczstore_main.add_command(copy_store_to_icechunk)

--- a/vczstore/rechunk.py
+++ b/vczstore/rechunk.py
@@ -12,7 +12,7 @@ def rechunk(
     backend_storage=None,
 ):
     """Rechunk a variants array with a larger variants chunk size that is
-    an exact multiple of the existing chunk size."""
+    an exact multiple of the min variants chunk size."""
 
     with transaction(vcz, backend_storage=backend_storage, message="rechunk") as vcz:
         root = open_zarr(vcz, mode="r+", backend_storage=backend_storage)

--- a/vczstore/rechunk.py
+++ b/vczstore/rechunk.py
@@ -14,13 +14,24 @@ def rechunk(
     """Rechunk a variants array with a larger variants chunk size that is
     an exact multiple of the existing chunk size."""
 
-    # TODO: check pre-conditions
-
     with transaction(vcz, backend_storage=backend_storage, message="rechunk") as vcz:
         root = open_zarr(vcz, mode="r+", backend_storage=backend_storage)
 
         var = variants_array_name
         arr = root[var]
+
+        if not has_variants_axis(arr):
+            raise ValueError(
+                f"Array '{var}' does not have variants as its first dimension"
+            )
+
+        min_chunk_size = compute_min_variants_chunk_size(root)
+        if variants_chunk_size % min_chunk_size != 0:
+            raise ValueError(
+                f"variants_chunk_size={variants_chunk_size} is not an exact multiple "
+                f"of the minimum variants chunk size {min_chunk_size}"
+            )
+
         new_chunks = (variants_chunk_size,) + arr.chunks[1:]
 
         # read entire array into memory
@@ -40,3 +51,43 @@ def rechunk(
             compressor=get_compressor_config(arr),
             dimension_names=array_dims(arr),
         )
+
+
+def has_variants_axis(arr) -> bool:
+    """Whether ``arr``'s first dimension is the variants axis."""
+    dims = array_dims(arr)
+    return dims is not None and len(dims) > 0 and dims[0] == "variants"
+
+
+def compute_min_variants_chunk_size(root) -> int:
+    """Compute the minimum variants-axis chunk size in a VCZ root.
+
+    By spec ``call_*`` fields define the floor; every variant-only
+    field must use a chunk size that is a positive integer multiple of
+    it. Two ``call_*`` fields with different chunk sizes are a writer
+    bug and raise ``ValueError`` here. When no ``call_*`` field is
+    present, falls back to the minimum chunk size across variant-axis
+    fields.
+    """
+    call_sizes: dict[str, int] = {}
+    other_sizes: list[int] = []
+    for name in root.array_keys():
+        arr = root[name]
+        if not has_variants_axis(arr):
+            continue
+        chunk_size = int(arr.chunks[0])
+        if name.startswith("call_"):
+            call_sizes[name] = chunk_size
+        else:
+            other_sizes.append(chunk_size)
+    if len(call_sizes) > 0:
+        sizes_set = set(call_sizes.values())
+        if len(sizes_set) > 1:
+            raise ValueError(
+                f"call_* fields must share a single variants chunk size; "
+                f"found {call_sizes}"
+            )
+        return next(iter(sizes_set))
+    if len(other_sizes) > 0:
+        return min(other_sizes)
+    raise ValueError("no variant-axis fields in store")

--- a/vczstore/rechunk.py
+++ b/vczstore/rechunk.py
@@ -1,8 +1,61 @@
+from bio2zarr.zarr_utils import create_empty_group_array, get_compressor_config
+from vcztools.utils import array_dims, open_zarr
+
+from vczstore.utils import transaction, variant_chunk_slices
+
+
 def rechunk(
     vcz,
     variants_array_name,
     variants_chunk_size,
     *,
-    backend_storage=None,
+    backend_storage="icechunk",
 ):
-    pass
+    """Rechunk a variants array with a larger variants chunk size that is
+    an exact multiple of the existing chunk size."""
+
+    if backend_storage != "icechunk":
+        raise ValueError("Only icechunk storage is supported for rechunk")
+
+    # TODO: check pre-conditions
+
+    var = variants_array_name
+    var_rechunked = f"{var}_rechunked"
+    var_delete = f"{var}_delete"
+
+    # separate transactions for data and restructuring operations as they can't be mixed
+    # https://icechunk.io/en/stable/guides/moving-nodes/#rearrange-sessions
+    with transaction(vcz, backend_storage=backend_storage, message="rechunk") as store:
+        root = open_zarr(store, mode="r+", backend_storage=backend_storage)
+        variant_chunks_in_batch = variants_chunk_size // root[var].chunks[0]
+
+        arr = root[var]
+
+        new_chunks = (variants_chunk_size,) + arr.chunks[1:]
+
+        create_empty_group_array(
+            root,
+            var_rechunked,
+            shape=arr.shape,
+            dtype=arr.dtype,
+            chunks=new_chunks,
+            compressor=get_compressor_config(arr),
+            dimension_names=array_dims(arr),
+        )
+        arr_rechunked = root[var_rechunked]
+
+        for v_sel in variant_chunk_slices(root, variant_chunks_in_batch):
+            arr_rechunked[v_sel, ...] = arr[v_sel, ...]
+
+    with transaction(
+        vcz, backend_storage=backend_storage, rearrange=True, message="rechunk rename"
+    ) as store:
+        session = store.session
+        session.move(f"/{var}", f"/{var_delete}")
+        session.move(f"/{var_rechunked}", f"/{var}")
+
+    with transaction(
+        vcz, backend_storage=backend_storage, message="rechunk delete"
+    ) as store:
+        root = open_zarr(store, mode="r+", backend_storage=backend_storage)
+        del root[var_delete]

--- a/vczstore/rechunk.py
+++ b/vczstore/rechunk.py
@@ -1,0 +1,8 @@
+def rechunk(
+    vcz,
+    variants_array_name,
+    variants_chunk_size,
+    *,
+    backend_storage=None,
+):
+    pass

--- a/vczstore/rechunk.py
+++ b/vczstore/rechunk.py
@@ -1,7 +1,7 @@
-from bio2zarr.zarr_utils import create_empty_group_array, get_compressor_config
+from bio2zarr.zarr_utils import create_group_array, get_compressor_config
 from vcztools.utils import array_dims, open_zarr
 
-from vczstore.utils import transaction, variant_chunk_slices
+from vczstore.utils import transaction
 
 
 def rechunk(
@@ -9,53 +9,34 @@ def rechunk(
     variants_array_name,
     variants_chunk_size,
     *,
-    backend_storage="icechunk",
+    backend_storage=None,
 ):
     """Rechunk a variants array with a larger variants chunk size that is
     an exact multiple of the existing chunk size."""
 
-    if backend_storage != "icechunk":
-        raise ValueError("Only icechunk storage is supported for rechunk")
-
     # TODO: check pre-conditions
 
-    var = variants_array_name
-    var_rechunked = f"{var}_rechunked"
-    var_delete = f"{var}_delete"
+    with transaction(vcz, backend_storage=backend_storage, message="rechunk") as vcz:
+        root = open_zarr(vcz, mode="r+", backend_storage=backend_storage)
 
-    # separate transactions for data and restructuring operations as they can't be mixed
-    # https://icechunk.io/en/stable/guides/moving-nodes/#rearrange-sessions
-    with transaction(vcz, backend_storage=backend_storage, message="rechunk") as store:
-        root = open_zarr(store, mode="r+", backend_storage=backend_storage)
-        variant_chunks_in_batch = variants_chunk_size // root[var].chunks[0]
-
+        var = variants_array_name
         arr = root[var]
-
         new_chunks = (variants_chunk_size,) + arr.chunks[1:]
 
-        create_empty_group_array(
+        # read entire array into memory
+        data = arr[:]
+
+        # delete the array
+        del root[var]
+
+        # recreate the array with new chunk size
+        create_group_array(
             root,
-            var_rechunked,
+            var,
+            data=data,
             shape=arr.shape,
             dtype=arr.dtype,
             chunks=new_chunks,
             compressor=get_compressor_config(arr),
             dimension_names=array_dims(arr),
         )
-        arr_rechunked = root[var_rechunked]
-
-        for v_sel in variant_chunk_slices(root, variant_chunks_in_batch):
-            arr_rechunked[v_sel, ...] = arr[v_sel, ...]
-
-    with transaction(
-        vcz, backend_storage=backend_storage, rearrange=True, message="rechunk rename"
-    ) as store:
-        session = store.session
-        session.move(f"/{var}", f"/{var_delete}")
-        session.move(f"/{var_rechunked}", f"/{var}")
-
-    with transaction(
-        vcz, backend_storage=backend_storage, message="rechunk delete"
-    ) as store:
-        root = open_zarr(store, mode="r+", backend_storage=backend_storage)
-        del root[var_delete]

--- a/vczstore/utils.py
+++ b/vczstore/utils.py
@@ -123,6 +123,7 @@ def transaction(
     backend_storage=None,
     branch="main",
     create_repo=False,
+    rearrange=False,
     message="update",
 ):
     """Create a transaction context manager.
@@ -132,7 +133,11 @@ def transaction(
     """
     if backend_storage == "icechunk":
         cm = icechunk_transaction(
-            file_or_url, branch, create_repo=create_repo, message=message
+            file_or_url,
+            branch,
+            create_repo=create_repo,
+            rearrange=rearrange,
+            message=message,
         )
     else:
         cm = nullcontext(file_or_url)
@@ -141,7 +146,9 @@ def transaction(
 
 
 @contextmanager
-def icechunk_transaction(file_or_url, branch, *, create_repo=False, message="update"):
+def icechunk_transaction(
+    file_or_url, branch, *, create_repo=False, rearrange=False, message="update"
+):
     """Open an Icechunk store in a transaction, then commit on completion.
 
     If `create_repo` is False then the previous commit will be amended so the
@@ -156,17 +163,23 @@ def icechunk_transaction(file_or_url, branch, *, create_repo=False, message="upd
             yield store
     else:
         repo = Repository.open(icechunk_storage)
-        with transaction_amend(repo, branch, message=message) as store:
+        with transaction_amend(
+            repo, branch, message=message, rearrange=rearrange
+        ) as store:
             yield store
 
 
 @contextmanager
-def transaction_amend(repo, branch, message):
+def transaction_amend(repo, branch, message, rearrange=False):
     """Like Icechunk's `transaction` context manager, but using amend not commit."""
-    session = repo.writable_session(branch)
+    session = (
+        repo.rearrange_session(branch) if rearrange else repo.writable_session(branch)
+    )
     yield session.store
     # use amend to overwrite previous commit
-    session.amend(message=message)
+    session.commit(
+        message=message
+    )  # TODO: amend not compaitble with rearrange sessions?
 
 
 def merge_with(

--- a/vczstore/utils.py
+++ b/vczstore/utils.py
@@ -123,7 +123,6 @@ def transaction(
     backend_storage=None,
     branch="main",
     create_repo=False,
-    rearrange=False,
     message="update",
 ):
     """Create a transaction context manager.
@@ -133,11 +132,7 @@ def transaction(
     """
     if backend_storage == "icechunk":
         cm = icechunk_transaction(
-            file_or_url,
-            branch,
-            create_repo=create_repo,
-            rearrange=rearrange,
-            message=message,
+            file_or_url, branch, create_repo=create_repo, message=message
         )
     else:
         cm = nullcontext(file_or_url)
@@ -146,9 +141,7 @@ def transaction(
 
 
 @contextmanager
-def icechunk_transaction(
-    file_or_url, branch, *, create_repo=False, rearrange=False, message="update"
-):
+def icechunk_transaction(file_or_url, branch, *, create_repo=False, message="update"):
     """Open an Icechunk store in a transaction, then commit on completion.
 
     If `create_repo` is False then the previous commit will be amended so the
@@ -163,23 +156,17 @@ def icechunk_transaction(
             yield store
     else:
         repo = Repository.open(icechunk_storage)
-        with transaction_amend(
-            repo, branch, message=message, rearrange=rearrange
-        ) as store:
+        with transaction_amend(repo, branch, message=message) as store:
             yield store
 
 
 @contextmanager
-def transaction_amend(repo, branch, message, rearrange=False):
+def transaction_amend(repo, branch, message):
     """Like Icechunk's `transaction` context manager, but using amend not commit."""
-    session = (
-        repo.rearrange_session(branch) if rearrange else repo.writable_session(branch)
-    )
+    session = repo.writable_session(branch)
     yield session.store
     # use amend to overwrite previous commit
-    session.commit(
-        message=message
-    )  # TODO: amend not compaitble with rearrange sessions?
+    session.amend(message=message)
 
 
 def merge_with(


### PR DESCRIPTION
Here is my first attempt - I'm just putting this here for discussion.

I don't think there is a way in Zarr to redefine the chunk size of an array, so I created a new array with the new chunk size, and copied the data across. Icechunk doesn't allow mixing data operations and structural modifications (moves) in one transaction (https://icechunk.io/en/stable/guides/moving-nodes/#groups-move-with-children), so I created separate transactions to do this. However, that doesn't work with amend (which we use to ensure there is no hisitory post remove), which could be a bug in Icechunk (~~I haven't investigated further~~ see https://github.com/earth-mover/icechunk/issues/2121).

But perhaps it would be simplest to just read the whole variant array into memory, delete the Zarr array, create a new Zarr array with the new chunking, then write it back - all in one transaction.

Thoughts @jeromekelleher, @benjeffery 

Fixes #97 