### PR TITLE
Check min variants chunk sizes are compatible

### DIFF
--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -96,7 +96,7 @@ def test_append_fail_alleles_mismatch():
         append(vcz1, vcz2)
 
 
-def test_append_fails_for_misaligned_variant_chunks():
+def test_append_fails_for_misaligned_call_chunks():
     vcz1 = make_vcz(
         variant_contig=[0, 0],
         variant_position=[1, 2],
@@ -130,48 +130,7 @@ def test_append_fails_for_misaligned_variant_chunks():
         variants_chunk_size=2,
     )
 
-    with pytest.raises(ValueError, match="VCZ-aligned variant chunks"):
-        append(vcz1, vcz2)
-
-    root1_after = zarr.open_group(store=vcz1, mode="r")
-    np.testing.assert_array_equal(root1_after["sample_id"][:], np.array(["S1"]))
-
-
-def test_append_fails_for_misaligned_source_variant_chunks():
-    vcz1 = make_vcz(
-        variant_contig=[0, 0],
-        variant_position=[1, 2],
-        alleles=[
-            ["A", "T"],
-            ["C", "G"],
-        ],
-        sample_id=["S1"],
-        call_genotype=[[[0, 1]], [[1, 1]]],
-        variants_chunk_size=2,
-    )
-
-    vcz2 = make_vcz(
-        variant_contig=[0, 0],
-        variant_position=[1, 2],
-        alleles=[
-            ["A", "T"],
-            ["C", "G"],
-        ],
-        sample_id=["S2"],
-        variants_chunk_size=2,
-    )
-    # create call_genotype with different variant chunks
-    root2 = zarr.open(vcz2, mode="r+")
-    root2.create_array(
-        "call_genotype",
-        data=np.array([[[0, 0]], [[0, 1]]], dtype=np.int8),
-        chunks=(1, 1, 2),
-        dimension_names=["variants", "samples", "ploidy"],
-        compressors=None,
-        filters=None,
-    )
-
-    with pytest.raises(ValueError, match="VCZ-aligned variant chunks"):
+    with pytest.raises(ValueError, match="matching minimum variants chunk sizes"):
         append(vcz1, vcz2)
 
     root1_after = zarr.open_group(store=vcz1, mode="r")

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -54,7 +54,7 @@ def test_remove():
     )
 
 
-def test_remove_fails_for_misaligned_variant_chunks():
+def test_remove_fails_for_misaligned_call_chunks():
     vcz = make_vcz(
         variant_contig=[0, 0],
         variant_position=[1, 2],
@@ -70,44 +70,22 @@ def test_remove_fails_for_misaligned_variant_chunks():
     root.create_array(
         "call_genotype",
         data=np.array([[[0, 1]], [[1, 1]]], dtype=np.int8),
-        chunks=(1, 1, 2),
+        chunks=(2, 1, 2),
         dimension_names=["variants", "samples", "ploidy"],
         compressors=None,
         filters=None,
     )
-
-    with pytest.raises(ValueError, match="VCZ-aligned variant chunks"):
-        remove(vcz, "S1")
-
-    root_after = zarr.open_group(store=vcz, mode="r")
-    np.testing.assert_array_equal(root_after["sample_id"][:], np.array(["S1"]))
-
-
-def test_remove_fails_for_malformed_call_array_dimensions():
-    vcz = make_vcz(
-        variant_contig=[0, 0],
-        variant_position=[1, 2],
-        alleles=[
-            ["A", "T"],
-            ["C", "G"],
-        ],
-        sample_id=["S1"],
-        variants_chunk_size=2,
-    )
-    # create call_quality with invalid dimensions
-    root = zarr.open(vcz, mode="r+")
     root.create_array(
         "call_quality",
         data=np.array([[10, 20], [30, 40]], dtype=np.int16),
-        chunks=(2, 2),
-        dimension_names=["variants", "not_samples"],
+        chunks=(1, 2),  # different chunk size in variants dimension
+        dimension_names=["variants", "samples"],
         compressors=None,
         filters=None,
     )
 
     with pytest.raises(
-        ValueError,
-        match="remove requires 'call_quality' to use variants/samples dimensions",
+        ValueError, match=r"call_\* fields must share a single variants chunk size"
     ):
         remove(vcz, "S1")
 

--- a/vczstore/append.py
+++ b/vczstore/append.py
@@ -9,21 +9,9 @@ from aiostream import stream
 from vcztools.utils import array_dims, open_zarr
 from zarr.core.sync import sync
 
-from vczstore.utils import copy_store, transaction
+from vczstore.utils import compute_min_variants_chunk_size, copy_store, transaction
 
 logger = logging.getLogger(__name__)
-
-
-def _assert_variant_chunk_alignment(arrays, *, variant_chunk_size, operation):
-    for name, arr in arrays:
-        dims = array_dims(arr)
-        if dims is None or len(dims) == 0 or dims[0] != "variants":
-            raise ValueError(f"{operation} requires {name!r} to be chunked on variants")
-        if arr.chunks is None or arr.chunks[0] != variant_chunk_size:
-            raise ValueError(
-                f"{operation} requires {name!r} to use VCZ-aligned variant chunks of "
-                f"size {variant_chunk_size}"
-            )
 
 
 def _assert_append_arrays_compatible(name, arr1, arr2):
@@ -150,6 +138,14 @@ def append(
                     f"Stores being appended must have same values for field '{field}'"
                 )
 
+        min_chunk_size1 = compute_min_variants_chunk_size(root1)
+        min_chunk_size2 = compute_min_variants_chunk_size(root2)
+        if min_chunk_size1 != min_chunk_size2:
+            raise ValueError(
+                f"append requires stores have matching minimum variants chunk sizes. "
+                f"First has {min_chunk_size1}, second has {min_chunk_size2}"
+            )
+
         call_arrays = []
         for var in root1.keys():
             if var.startswith("call_"):
@@ -162,16 +158,6 @@ def append(
                 arr1_num_sample_chunks = arr1.cdata_shape[1]
                 _assert_append_arrays_compatible(var, arr1, arr2)
                 call_arrays.append((var, arr1, arr2, arr1_num_sample_chunks))
-        _assert_variant_chunk_alignment(
-            [(var, arr1) for var, arr1, _, _ in call_arrays],
-            variant_chunk_size=root1["variant_contig"].chunks[0],
-            operation="append",
-        )
-        _assert_variant_chunk_alignment(
-            [(var, arr2) for var, _, arr2, _ in call_arrays],
-            variant_chunk_size=root2["variant_contig"].chunks[0],
-            operation="append",
-        )
 
         # append samples
         old_num_samples = sample_id1.shape[0]

--- a/vczstore/normalise.py
+++ b/vczstore/normalise.py
@@ -7,6 +7,7 @@ from vcztools.constants import INT_FILL, INT_MISSING, STR_FILL, STR_MISSING
 from vcztools.utils import array_dims, open_zarr, search
 
 from vczstore.utils import (
+    compute_min_variants_chunk_size,
     copy_store,
     missing_val,
     progress_bar,
@@ -57,8 +58,10 @@ def normalise(
     norm_root = zarr.open(vcz2_norm, mode="w", zarr_format=root2.metadata.zarr_format)
 
     n_variants = root1["variant_contig"].shape[0]
-    variants_chunk_size = root1["variant_contig"].chunks[0]
+    min_chunk_size = compute_min_variants_chunk_size(root1)
     norm_root.attrs.update(root2.attrs)
+
+    variant_contig1 = root1["variant_contig"]
 
     if haploid_contigs is None:
         haploid_contigs = ["X", "Y", "MT"]
@@ -89,7 +92,7 @@ def normalise(
                         f"variable {var}"
                     )
             shape = (n_variants,) + arr.shape[1:]
-            chunks = (variants_chunk_size,) + arr.chunks[1:]
+            chunks = (min_chunk_size,) + arr.chunks[1:]
             create_empty_group_array(
                 norm_root,
                 var,
@@ -137,17 +140,15 @@ def normalise(
 
     # find chunk boundaries
     chunk_bounds = np.arange(
-        0, n_variants, step=variants_chunk_size * variant_chunks_in_batch
+        0, n_variants, step=min_chunk_size * variant_chunks_in_batch
     )
     chunk_bounds = np.append(chunk_bounds, [n_variants])
 
     # find chunk offsets for indexes
     match_starts = np.searchsorted(match_idx, chunk_bounds)
     remap_starts = np.searchsorted(remap_idx, chunk_bounds)
-    update_starts = np.searchsorted(update_idx, chunk_bounds)
 
     allele_mappings_list = list(allele_mappings.values())
-    updated_allele_mappings_list = list(updated_allele_mappings.values())
 
     with progress_bar(n_variants, "Write", show_progress) as pbar:
         for i, v_sel in enumerate(variant_chunk_slices(root1, variant_chunks_in_batch)):
@@ -162,7 +163,7 @@ def normalise(
                 if var == "call_genotype":
                     data = np.full(shape, fill_value=INT_MISSING, dtype=arr.dtype)
                     if contig_ploidy is not None:
-                        variant_ploidy = contig_ploidy[root1["variant_contig"][v_sel]]
+                        variant_ploidy = contig_ploidy[variant_contig1[v_sel]]
                         for ploidy in range(1, data.shape[-1]):
                             ploidy_mask = variant_ploidy == ploidy
                             data[ploidy_mask, :, ploidy:] = INT_FILL
@@ -183,19 +184,13 @@ def normalise(
 
                 norm_root[var][v_sel] = data
 
-            # update variant_allele if needed
-            if len(update_idx) > 0:
-                var = "variant_allele"
-                data = root1[var][v_sel, :]
-                update_sl = slice(update_starts[i], update_starts[i + 1])
-                local_update_idx = update_idx[update_sl] - v_sel.start
-                chunk_maps = updated_allele_mappings_list[update_sl]
-                update_variant_alleles(data, local_update_idx, chunk_maps)
-                norm_root[var][v_sel] = data
-
             pbar.update(v_sel.stop - v_sel.start)
 
+    # update variant_allele if needed
     if len(update_idx) > 0:
+        data = root1["variant_allele"][:]
+        update_variant_alleles(data, update_idx, updated_allele_mappings.values())
+        norm_root["variant_allele"][:] = data
         norm_root["variant_allele"].attrs["normalise_new_alleles"] = True
 
 

--- a/vczstore/rechunk.py
+++ b/vczstore/rechunk.py
@@ -1,7 +1,11 @@
 from bio2zarr.zarr_utils import create_group_array, get_compressor_config
 from vcztools.utils import array_dims, open_zarr
 
-from vczstore.utils import transaction
+from vczstore.utils import (
+    compute_min_variants_chunk_size,
+    has_variants_axis,
+    transaction,
+)
 
 
 def rechunk(
@@ -51,43 +55,3 @@ def rechunk(
             compressor=get_compressor_config(arr),
             dimension_names=array_dims(arr),
         )
-
-
-def has_variants_axis(arr) -> bool:
-    """Whether ``arr``'s first dimension is the variants axis."""
-    dims = array_dims(arr)
-    return dims is not None and len(dims) > 0 and dims[0] == "variants"
-
-
-def compute_min_variants_chunk_size(root) -> int:
-    """Compute the minimum variants-axis chunk size in a VCZ root.
-
-    By spec ``call_*`` fields define the floor; every variant-only
-    field must use a chunk size that is a positive integer multiple of
-    it. Two ``call_*`` fields with different chunk sizes are a writer
-    bug and raise ``ValueError`` here. When no ``call_*`` field is
-    present, falls back to the minimum chunk size across variant-axis
-    fields.
-    """
-    call_sizes: dict[str, int] = {}
-    other_sizes: list[int] = []
-    for name in root.array_keys():
-        arr = root[name]
-        if not has_variants_axis(arr):
-            continue
-        chunk_size = int(arr.chunks[0])
-        if name.startswith("call_"):
-            call_sizes[name] = chunk_size
-        else:
-            other_sizes.append(chunk_size)
-    if len(call_sizes) > 0:
-        sizes_set = set(call_sizes.values())
-        if len(sizes_set) > 1:
-            raise ValueError(
-                f"call_* fields must share a single variants chunk size; "
-                f"found {call_sizes}"
-            )
-        return next(iter(sizes_set))
-    if len(other_sizes) > 0:
-        return min(other_sizes)
-    raise ValueError("no variant-axis fields in store")

--- a/vczstore/remove.py
+++ b/vczstore/remove.py
@@ -3,28 +3,15 @@ import logging
 import numpy as np
 from vcztools.utils import array_dims, open_zarr, search
 
-from vczstore.utils import missing_val, progress_bar, transaction, variant_chunk_slices
+from vczstore.utils import (
+    compute_min_variants_chunk_size,
+    missing_val,
+    progress_bar,
+    transaction,
+    variant_chunk_slices,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def _assert_variant_chunk_alignment(arrays, *, variant_chunk_size, operation):
-    for name, arr in arrays:
-        dims = array_dims(arr)
-        if (
-            dims is None
-            or len(dims) < 2
-            or dims[0] != "variants"
-            or dims[1] != "samples"
-        ):
-            raise ValueError(
-                f"{operation} requires {name!r} to use variants/samples dimensions"
-            )
-        if arr.chunks is None or arr.chunks[0] != variant_chunk_size:
-            raise ValueError(
-                f"{operation} requires {name!r} to use VCZ-aligned variant chunks of "
-                f"size {variant_chunk_size}"
-            )
 
 
 def remove(
@@ -47,21 +34,14 @@ def remove(
         n_variants = root["variant_contig"].shape[0]
         all_samples = root["sample_id"][:]
 
+        # check that all call_* fields have same variant chunk size
+        compute_min_variants_chunk_size(root)
+
         # find index of sample to remove
         unknown_samples = np.setdiff1d(sample_id, all_samples)
         if len(unknown_samples) > 0:
             raise ValueError(f"unrecognised sample: {sample_id}")
         sample_selection = search(all_samples, sample_id)
-
-        target_arrays = [
-            (name, arr) for name, arr in root.arrays() if name.startswith("call_")
-        ]
-
-        _assert_variant_chunk_alignment(
-            target_arrays,
-            variant_chunk_size=root["variant_contig"].chunks[0],
-            operation="remove",
-        )
 
         # overwrite sample data
         root["sample_id"][sample_selection] = ""

--- a/vczstore/utils.py
+++ b/vczstore/utils.py
@@ -7,7 +7,7 @@ import tqdm
 from aiostream import stream
 from bio2zarr.vcf_utils import ceildiv
 from vcztools.constants import FLOAT32_MISSING, INT_MISSING, STR_MISSING
-from vcztools.utils import make_icechunk_storage
+from vcztools.utils import array_dims, make_icechunk_storage
 from zarr.core.buffer.core import default_buffer_prototype
 from zarr.core.sync import sync
 from zarr.storage._common import make_store
@@ -30,11 +30,56 @@ def missing_val(arr):
         raise ValueError(f"unrecognised dtype: {arr.dtype}")
 
 
+def has_variants_axis(arr) -> bool:
+    """Whether ``arr``'s first dimension is the variants axis."""
+    dims = array_dims(arr)
+    return dims is not None and len(dims) > 0 and dims[0] == "variants"
+
+
+def compute_min_variants_chunk_size(root) -> int:
+    """Compute the minimum variants-axis chunk size in a VCZ root.
+
+    By spec ``call_*`` fields define the floor; every variant-only
+    field must use a chunk size that is a positive integer multiple of
+    it. Two ``call_*`` fields with different chunk sizes are a writer
+    bug and raise ``ValueError`` here. When no ``call_*`` field is
+    present, falls back to the minimum chunk size across variant-axis
+    fields.
+    """
+    call_sizes: dict[str, int] = {}
+    other_sizes: list[int] = []
+    for name in root.array_keys():
+        arr = root[name]
+        if not has_variants_axis(arr):
+            continue
+        chunk_size = int(arr.chunks[0])
+        if name.startswith("call_"):
+            call_sizes[name] = chunk_size
+        else:
+            other_sizes.append(chunk_size)
+    if len(call_sizes) > 0:
+        sizes_set = set(call_sizes.values())
+        if len(sizes_set) > 1:
+            raise ValueError(
+                f"call_* fields must share a single variants chunk size; "
+                f"found {call_sizes}"
+            )
+        return next(iter(sizes_set))
+    if len(other_sizes) > 0:
+        return min(other_sizes)
+    raise ValueError("no variant-axis fields in store")
+
+
 def variant_chunk_slices(root, variant_chunks_in_batch=1):
-    """A generator returning chunk slices along the variants dimension."""
+    """A generator returning chunk slices along the variants dimension.
+
+    Batches are in multiples of the minimum variants-axis chunk size as
+    found by `compute_min_variants_chunk_size`.
+    """
     pos = root["variant_position"]
     size = pos.shape[0]
-    v_chunksize = pos.chunks[0] * variant_chunks_in_batch
+    min_chunk_size = compute_min_variants_chunk_size(root)
+    v_chunksize = min_chunk_size * variant_chunks_in_batch
     for v_chunk in range(ceildiv(size, v_chunksize)):
         start = v_chunksize * v_chunk
         end = min(v_chunksize * (v_chunk + 1), size)


### PR DESCRIPTION
Following #98, there is no single variant chunk size. This changes various checks that assumed a single variant chunk size, and replaces them with checks for the minimum chunk size.

See also https://github.com/sgkit-dev/vcztools/pull/356